### PR TITLE
Add Max Froumentin as an owner of GCP

### DIFF
--- a/terraform/main-gcp.tf
+++ b/terraform/main-gcp.tf
@@ -149,6 +149,7 @@ data "google_iam_policy" "project" {
     role = "roles/owner"
     members = [
       "user:duncan.garmonsway@digital.cabinet-office.gov.uk",
+      "user:max.froumentin@digital.cabinet-office.gov.uk",
     ]
   }
 


### PR DESCRIPTION
Add Max Froumentin as an owner of the GCP project.
