### PR TITLE
Notify pubsub on storage object creation

### DIFF
--- a/terraform/main-gcp.tf
+++ b/terraform/main-gcp.tf
@@ -66,6 +66,7 @@ variable "services" {
     # List all the services you use here
     "storage.googleapis.com",
     "iam.googleapis.com",
+    "pubsub.googleapis.com",
     "sourcerepo.googleapis.com",
     "storagetransfer.googleapis.com"
   ]

--- a/terraform/storage.tf
+++ b/terraform/storage.tf
@@ -1,3 +1,5 @@
+data "google_storage_project_service_account" "default" {}
+
 # Bucket for a copy of the current state of the git repository
 resource "google_storage_bucket" "repository" {
   name                        = "${var.project_id}-repository" # Must be globally unique


### PR DESCRIPTION
Notify other projects when files are created in the bucket that mirrors
GOV.UK's S3 bucket, so that they can react as soon as possible.

Only PubSub notifications can be subscribed to by other projects.  The
newer EventArc and CloudEvent system only works within projects.
Projects may subscribe to the PubSub topic via EventArc to pass events
onto services that are compatible with EventArc.

References:
- https://github.com/alphagov/govuk-knowledge-graph-gcp/issues/120
- https://cloud.google.com/blog/topics/developers-practitioners/cross-region-and-cross-project-event-routing-eventarc-and-pubsub
- https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_notification
