### PR TITLE
Notify govuk-knowledge-graph PubSub topic

### DIFF
--- a/terraform/transfer.tf
+++ b/terraform/transfer.tf
@@ -110,37 +110,3 @@ resource "google_storage_transfer_job" "govuk-integration-database-backups" {
     repeat_interval = "3600s"
   }
 }
-
-# Send notifications to pubusb
-resource "google_pubsub_topic" "govuk_integration_database_backups" {
-  name                       = "govuk-integration-database-backups"
-  message_retention_duration = "604800s" # 604800 seconds is 7 days
-  message_storage_policy {
-    allowed_persistence_regions = [
-      var.region,
-    ]
-  }
-}
-
-resource "google_storage_notification" "notification" {
-  bucket         = google_storage_bucket.govuk-integration-database-backups.name
-  payload_format = "JSON_API_V1"
-  topic          = google_pubsub_topic.govuk_integration_database_backups.id
-  event_types    = ["OBJECT_FINALIZE"]
-  depends_on     = [google_pubsub_topic_iam_policy.govuk_integration_database_backups]
-}
-
-// Enable notifications by giving the correct IAM permission to the unique service account.
-data "google_iam_policy" "pubsub_topic-govuk_integration_database_backups" {
-  binding {
-    role = "roles/pubsub.publisher"
-    members = [
-      "serviceAccount:${data.google_storage_project_service_account.default.email_address}"
-    ]
-  }
-}
-
-resource "google_pubsub_topic_iam_policy" "govuk_integration_database_backups" {
-  topic       = google_pubsub_topic.govuk_integration_database_backups.name
-  policy_data = data.google_iam_policy.pubsub_topic-govuk_integration_database_backups.policy_data
-}


### PR DESCRIPTION
Send bucket notifications to a PubSub topic in the govuk-knowledge-graph
project.  That project give this project's bucket's default service
account permission to publish to it.
