### PR TITLE
Allow knowledge graph postgres instance access

### DIFF
--- a/terraform/transfer.tf
+++ b/terraform/transfer.tf
@@ -30,6 +30,7 @@ data "google_iam_policy" "bucket_govuk-integration-database-backups" {
       "group:data-products@digital.cabinet-office.gov.uk",
       "group:data-insights@digital.cabinet-office.gov.uk",
       "serviceAccount:gce-mongodb@govuk-knowledge-graph.iam.gserviceaccount.com",
+      "serviceAccount:gce-postgres@govuk-knowledge-graph.iam.gserviceaccount.com",
       "user:matthew.gregory@digital.cabinet-office.gov.uk",
     ]
   }


### PR DESCRIPTION
The postgres instance of the Knowledge Graph needs access to the bucket
to download the Publishing API database.
