### PR TITLE
Add notification for new feedback project

### DIFF
--- a/terraform/pubsub.tf
+++ b/terraform/pubsub.tf
@@ -111,3 +111,14 @@ resource "google_storage_notification" "support_api_backup_staging" {
   event_types        = ["OBJECT_FINALIZE"]
   object_name_prefix = "support-api-postgres/"
 }
+
+# =========================================================
+# Notify a PubSub topic in the govuk-user-feedback-dev project
+# =========================================================
+resource "google_storage_notification" "support_api_backup_staging2" {
+  bucket             = google_storage_bucket.govuk-integration-database-backups.name
+  payload_format     = "JSON_API_V1"
+  topic              = "projects/govuk-user-feedback-dev/topics/support-api-backup-staging"
+  event_types        = ["OBJECT_FINALIZE"]
+  object_name_prefix = "support-api-postgres/"
+}


### PR DESCRIPTION
We're creating a series of new, more aptly-named GCP projects for the feedback work because "govuk-analytics-test" as a project name is not particularly descriptive.

A new pub/sub notification is required for the first of these new projects (govuk-user-feedback-dev).

This new pub/sub notification is exactly the same as the one for govuk-analytics-test - just pointed at the new project.