### PR TITLE
Include the new postgres content store

### DIFF
--- a/terraform/pubsub.tf
+++ b/terraform/pubsub.tf
@@ -53,16 +53,12 @@ resource "google_pubsub_subscription" "govuk_integration_database_backups" {
 # ===================================================
 # A PubSub topic in the govuk-knowledge-graph project
 # ===================================================
-data "google_pubsub_topic" "govuk_integration_database_backups-govuk_knowledge_graph" {
-  project                    = "govuk-knowledge-graph"
-  name                       = "govuk-integration-database-backups"
-}
 
 # Notify the topic from the bucket
 resource "google_storage_notification" "govuk_integration_database_backups-govuk_knowledge_graph" {
   bucket         = google_storage_bucket.govuk-integration-database-backups.name
   payload_format = "JSON_API_V1"
-  topic          = data.google_pubsub_topic.govuk_integration_database_backups-govuk_knowledge_graph.id
+  topic          = "/projects/govuk-knowledge-graph/topics/govuk-integration-database-backups"
   event_types    = ["OBJECT_FINALIZE"]
   depends_on     = [google_pubsub_topic_iam_policy.govuk_integration_database_backups]
 }
@@ -70,16 +66,12 @@ resource "google_storage_notification" "govuk_integration_database_backups-govuk
 # =======================================================
 # A PubSub topic in the govuk-knowledge-graph-staging project
 # =======================================================
-data "google_pubsub_topic" "govuk_integration_database_backups-govuk_knowledge_graph_staging" {
-  project                    = "govuk-knowledge-graph-staging"
-  name                       = "govuk-integration-database-backups"
-}
 
 # Notify the topic from the bucket
 resource "google_storage_notification" "govuk_integration_database_backups-govuk_knowledge_graph_staging" {
   bucket         = google_storage_bucket.govuk-integration-database-backups.name
   payload_format = "JSON_API_V1"
-  topic          = data.google_pubsub_topic.govuk_integration_database_backups-govuk_knowledge_graph_staging.id
+  topic          = "/projects/govuk-knowledge-graph-staging/topics/govuk-integration-database-backups"
   event_types    = ["OBJECT_FINALIZE"]
   depends_on     = [google_pubsub_topic_iam_policy.govuk_integration_database_backups]
 }
@@ -87,16 +79,12 @@ resource "google_storage_notification" "govuk_integration_database_backups-govuk
 # =======================================================
 # A PubSub topic in the govuk-knowledge-graph-dev project
 # =======================================================
-data "google_pubsub_topic" "govuk_integration_database_backups-govuk_knowledge_graph_dev" {
-  project                    = "govuk-knowledge-graph-dev"
-  name                       = "govuk-integration-database-backups"
-}
 
 # Notify the topic from the bucket
 resource "google_storage_notification" "govuk_integration_database_backups-govuk_knowledge_graph_dev" {
   bucket         = google_storage_bucket.govuk-integration-database-backups.name
   payload_format = "JSON_API_V1"
-  topic          = data.google_pubsub_topic.govuk_integration_database_backups-govuk_knowledge_graph_dev.id
+  topic          = "/projects/govuk-knowledge-graph-dev/topics/govuk-integration-database-backups"
   event_types    = ["OBJECT_FINALIZE"]
   depends_on     = [google_pubsub_topic_iam_policy.govuk_integration_database_backups]
 }

--- a/terraform/transfer.tf
+++ b/terraform/transfer.tf
@@ -79,6 +79,7 @@ resource "google_storage_transfer_job" "govuk-integration-database-backups" {
   transfer_spec {
     object_conditions {
       include_prefixes = [
+        "content-store-postgres/",
         "publishing-api-postgres/",
         "support-api-postgres/",
         "mongo-api/",


### PR DESCRIPTION
The Content Store database is being migrated from MongoDB to PostgreSQL.
See https://github.com/alphagov/content-store/pull/1085.

Nightly backups of the postgres database are now available in s3://govuk-integration-database-backups/content-store-postgres/.  By copying them to Google Cloud Platform, we make it possible to adapt the GOV.UK Knowledge Graph to use them.  We can include them by including the prefix `content-store-postgres/` among others that are already being copied.

Terraform plan:

```text
Terraform will perform the following actions:

  # google_storage_transfer_job.govuk-integration-database-backups will be updated in-place
  ~ resource "google_storage_transfer_job" "govuk-integration-database-backups" {
        id                     = "govuk-s3-mirror/3250426811164964773"
        name                   = "transferJobs/3250426811164964773"
        # (5 unchanged attributes hidden)

      ~ transfer_spec {
          ~ object_conditions {
              ~ include_prefixes = [
                  + "content-store-postgres/",
                    "publishing-api-postgres/",
                    # (2 unchanged elements hidden)
                ]
                # (1 unchanged attribute hidden)
            }

            # (3 unchanged blocks hidden)
        }

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```