### PR TITLE
Allow service account to download from bucket

### DIFF
--- a/terraform/transfer.tf
+++ b/terraform/transfer.tf
@@ -29,10 +29,13 @@ data "google_iam_policy" "bucket_govuk-integration-database-backups" {
       "group:data-engineering@digital.cabinet-office.gov.uk",
       "serviceAccount:gce-mongodb@govuk-knowledge-graph.iam.gserviceaccount.com",
       "serviceAccount:gce-postgres@govuk-knowledge-graph.iam.gserviceaccount.com",
+      "serviceAccount:gce-content@govuk-knowledge-graph.iam.gserviceaccount.com",
       "serviceAccount:gce-mongodb@govuk-knowledge-graph-staging.iam.gserviceaccount.com",
       "serviceAccount:gce-postgres@govuk-knowledge-graph-staging.iam.gserviceaccount.com",
+      "serviceAccount:gce-content@govuk-knowledge-graph-staging.iam.gserviceaccount.com",
       "serviceAccount:gce-mongodb@govuk-knowledge-graph-dev.iam.gserviceaccount.com",
-      "serviceAccount:gce-postgres@govuk-knowledge-graph-dev.iam.gserviceaccount.com"
+      "serviceAccount:gce-postgres@govuk-knowledge-graph-dev.iam.gserviceaccount.com",
+      "serviceAccount:gce-content@govuk-knowledge-graph-dev.iam.gserviceaccount.com",
     ]
   }
 


### PR DESCRIPTION
Allow a service account in the govuk-knowledge-graph projects to
download from the bucket of database backup files.
