### PR TITLE
Include the Publisher app database backup

### DIFF
--- a/terraform/transfer.tf
+++ b/terraform/transfer.tf
@@ -83,9 +83,10 @@ resource "google_storage_transfer_job" "govuk-integration-database-backups" {
     object_conditions {
       include_prefixes = [
         "content-store-postgres/",
-        "publishing-api-postgres/",
-        "support-api-postgres/",
         "mongo-api/",
+        "publishing-api-postgres/",
+        "shared-documentdb/",
+        "support-api-postgres/",
       ]
     }
     transfer_options {


### PR DESCRIPTION
We can't avoid including five other databases that we don't currently
require, because only a prefix filter is available, not a wildcard
filter, and the object names have the timestamp before the name of the
database. All the files are all smallish, however (under 1GB).
