### PR TITLE
feat: allow a Knowledge Graph service account

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ projects.  This is configured by the blocks at the bottom of the file
 To receive notifications in a new project:
 
 1. Create a PubSub topic in the new project
-2. Give this project permission to publish to the PubSub topic by givin the
+2. Give this project permission to publish to the PubSub topic by giving the
    service account
    `service-384988117066@gs-project-accounts.iam.gserviceaccount.com` the role
    `roles/pubsub.publisher` in relation to the PubSub topic.

--- a/terraform/transfer.tf
+++ b/terraform/transfer.tf
@@ -27,15 +27,18 @@ data "google_iam_policy" "bucket_govuk-integration-database-backups" {
     role = "roles/storage.objectViewer"
     members = [
       "group:data-engineering@digital.cabinet-office.gov.uk",
-      "serviceAccount:gce-mongodb@govuk-knowledge-graph.iam.gserviceaccount.com",
-      "serviceAccount:gce-postgres@govuk-knowledge-graph.iam.gserviceaccount.com",
-      "serviceAccount:gce-content@govuk-knowledge-graph.iam.gserviceaccount.com",
-      "serviceAccount:gce-mongodb@govuk-knowledge-graph-staging.iam.gserviceaccount.com",
-      "serviceAccount:gce-postgres@govuk-knowledge-graph-staging.iam.gserviceaccount.com",
-      "serviceAccount:gce-content@govuk-knowledge-graph-staging.iam.gserviceaccount.com",
-      "serviceAccount:gce-mongodb@govuk-knowledge-graph-dev.iam.gserviceaccount.com",
-      "serviceAccount:gce-postgres@govuk-knowledge-graph-dev.iam.gserviceaccount.com",
       "serviceAccount:gce-content@govuk-knowledge-graph-dev.iam.gserviceaccount.com",
+      "serviceAccount:gce-content@govuk-knowledge-graph-staging.iam.gserviceaccount.com",
+      "serviceAccount:gce-content@govuk-knowledge-graph.iam.gserviceaccount.com",
+      "serviceAccount:gce-mongodb@govuk-knowledge-graph-dev.iam.gserviceaccount.com",
+      "serviceAccount:gce-mongodb@govuk-knowledge-graph-staging.iam.gserviceaccount.com",
+      "serviceAccount:gce-mongodb@govuk-knowledge-graph.iam.gserviceaccount.com",
+      "serviceAccount:gce-postgres@govuk-knowledge-graph-dev.iam.gserviceaccount.com",
+      "serviceAccount:gce-postgres@govuk-knowledge-graph-staging.iam.gserviceaccount.com",
+      "serviceAccount:gce-postgres@govuk-knowledge-graph.iam.gserviceaccount.com",
+      "serviceAccount:gce-publisher@govuk-knowledge-graph-dev.iam.gserviceaccount.com",
+      "serviceAccount:gce-publisher@govuk-knowledge-graph-staging.iam.gserviceaccount.com",
+      "serviceAccount:gce-publisher@govuk-knowledge-graph.iam.gserviceaccount.com",
     ]
   }
 


### PR DESCRIPTION
gce-publisher@govuk-knowledge-graph.iam.gserviceaccount.com and its
non-production counterparts need read-only access to the database backup
files.

I've taken the opportunity to sort the list of accounts.
