### PR TITLE
Use staging database backups

### DIFF
--- a/terraform/pubsub.tf
+++ b/terraform/pubsub.tf
@@ -6,7 +6,7 @@ moved {
   to   = google_pubsub_topic.govuk_database_backups
 }
 resource "google_pubsub_topic" "govuk_database_backups" {
-  name                       = "govuk-integration-database-backups"
+  name                       = "govuk-database-backups"
   message_retention_duration = "604800s" # 604800 seconds is 7 days
   message_storage_policy {
     allowed_persistence_regions = [
@@ -54,7 +54,7 @@ moved {
   to   = google_pubsub_subscription.govuk_database_backups
 }
 resource "google_pubsub_subscription" "govuk_database_backups" {
-  name  = "govuk-integration-database-backups"
+  name  = "govuk-database-backups"
   topic = google_pubsub_topic.govuk_database_backups.name
 
   message_retention_duration = "604800s" # 604800 seconds is 7 days
@@ -79,7 +79,7 @@ moved {
 resource "google_storage_notification" "govuk_database_backups-govuk_knowledge_graph" {
   bucket         = google_storage_bucket.govuk_database_backups.name
   payload_format = "JSON_API_V1"
-  topic          = "/projects/govuk-knowledge-graph/topics/govuk-integration-database-backups"
+  topic          = "/projects/govuk-knowledge-graph/topics/govuk-database-backups"
   event_types    = ["OBJECT_FINALIZE"]
   depends_on     = [google_pubsub_topic_iam_policy.govuk_database_backups]
 }
@@ -96,7 +96,7 @@ moved {
 resource "google_storage_notification" "govuk_database_backups-govuk_knowledge_graph_staging" {
   bucket         = google_storage_bucket.govuk_database_backups.name
   payload_format = "JSON_API_V1"
-  topic          = "/projects/govuk-knowledge-graph-staging/topics/govuk-integration-database-backups"
+  topic          = "/projects/govuk-knowledge-graph-staging/topics/govuk-database-backups"
   event_types    = ["OBJECT_FINALIZE"]
   depends_on     = [google_pubsub_topic_iam_policy.govuk_database_backups]
 }
@@ -113,7 +113,7 @@ moved {
 resource "google_storage_notification" "govuk_database_backups-govuk_knowledge_graph_dev" {
   bucket         = google_storage_bucket.govuk_database_backups.name
   payload_format = "JSON_API_V1"
-  topic          = "/projects/govuk-knowledge-graph-dev/topics/govuk-integration-database-backups"
+  topic          = "/projects/govuk-knowledge-graph-dev/topics/govuk-backups"
   event_types    = ["OBJECT_FINALIZE"]
   depends_on     = [google_pubsub_topic_iam_policy.govuk_database_backups]
 }

--- a/terraform/pubsub.tf
+++ b/terraform/pubsub.tf
@@ -1,7 +1,11 @@
 # ==============================
 # A PubSub topic in this project
 # ==============================
-resource "google_pubsub_topic" "govuk_integration_database_backups" {
+moved {
+  from = google_pubsub_topic.govuk_integration_database_backups
+  to   = google_pubsub_topic.govuk_database_backups
+}
+resource "google_pubsub_topic" "govuk_database_backups" {
   name                       = "govuk-integration-database-backups"
   message_retention_duration = "604800s" # 604800 seconds is 7 days
   message_storage_policy {
@@ -13,7 +17,7 @@ resource "google_pubsub_topic" "govuk_integration_database_backups" {
 
 // Allow the bucket to send notifications to topic
 data "google_storage_project_service_account" "default" {}
-data "google_iam_policy" "pubsub_topic-govuk_integration_database_backups" {
+data "google_iam_policy" "pubsub_topic-govuk_database_backups" {
   binding {
     role = "roles/pubsub.publisher"
     members = [
@@ -22,24 +26,36 @@ data "google_iam_policy" "pubsub_topic-govuk_integration_database_backups" {
   }
 }
 
-resource "google_pubsub_topic_iam_policy" "govuk_integration_database_backups" {
-  topic       = google_pubsub_topic.govuk_integration_database_backups.name
-  policy_data = data.google_iam_policy.pubsub_topic-govuk_integration_database_backups.policy_data
+moved {
+  from = google_pubsub_topic_iam_policy.govuk_integration_database_backups
+  to   = google_pubsub_topic_iam_policy.govuk_database_backups
+}
+resource "google_pubsub_topic_iam_policy" "govuk_database_backups" {
+  topic       = google_pubsub_topic.govuk_database_backups.name
+  policy_data = data.google_iam_policy.pubsub_topic-govuk_database_backups.policy_data
 }
 
 # Notify the topic from the bucket
-resource "google_storage_notification" "govuk_integration_database_backups" {
-  bucket         = google_storage_bucket.govuk-integration-database-backups.name
+moved {
+  from = google_storage_notification.govuk_integration_database_backups
+  to   = google_storage_notification.govuk_database_backups
+}
+resource "google_storage_notification" "govuk_database_backups" {
+  bucket         = google_storage_bucket.govuk_database_backups.name
   payload_format = "JSON_API_V1"
-  topic          = google_pubsub_topic.govuk_integration_database_backups.id
+  topic          = google_pubsub_topic.govuk_database_backups.id
   event_types    = ["OBJECT_FINALIZE"]
-  depends_on     = [google_pubsub_topic_iam_policy.govuk_integration_database_backups]
+  depends_on     = [google_pubsub_topic_iam_policy.govuk_database_backups]
 }
 
 # Subscribe to the topic (so that it can be monitored in the console)
-resource "google_pubsub_subscription" "govuk_integration_database_backups" {
+moved {
+  from = google_pubsub_subscription.govuk_integration_database_backups
+  to   = google_pubsub_subscription.govuk_database_backups
+}
+resource "google_pubsub_subscription" "govuk_database_backups" {
   name  = "govuk-integration-database-backups"
-  topic = google_pubsub_topic.govuk_integration_database_backups.name
+  topic = google_pubsub_topic.govuk_database_backups.name
 
   message_retention_duration = "604800s" # 604800 seconds is 7 days
   retain_acked_messages      = true
@@ -56,12 +72,16 @@ resource "google_pubsub_subscription" "govuk_integration_database_backups" {
 # ===================================================
 
 # Notify the topic from the bucket
-resource "google_storage_notification" "govuk_integration_database_backups-govuk_knowledge_graph" {
-  bucket         = google_storage_bucket.govuk-integration-database-backups.name
+moved {
+  from = google_storage_notification.govuk_integration_database_backups-govuk_knowledge_graph
+  to   = google_storage_notification.govuk_database_backups-govuk_knowledge_graph
+}
+resource "google_storage_notification" "govuk_database_backups-govuk_knowledge_graph" {
+  bucket         = google_storage_bucket.govuk_database_backups.name
   payload_format = "JSON_API_V1"
   topic          = "/projects/govuk-knowledge-graph/topics/govuk-integration-database-backups"
   event_types    = ["OBJECT_FINALIZE"]
-  depends_on     = [google_pubsub_topic_iam_policy.govuk_integration_database_backups]
+  depends_on     = [google_pubsub_topic_iam_policy.govuk_database_backups]
 }
 
 # =======================================================
@@ -69,12 +89,16 @@ resource "google_storage_notification" "govuk_integration_database_backups-govuk
 # =======================================================
 
 # Notify the topic from the bucket
-resource "google_storage_notification" "govuk_integration_database_backups-govuk_knowledge_graph_staging" {
-  bucket         = google_storage_bucket.govuk-integration-database-backups.name
+moved {
+  from = google_storage_notification.govuk_integration_database_backups-govuk_knowledge_graph_staging
+  to   = google_storage_notification.govuk_database_backups-govuk_knowledge_graph_staging
+}
+resource "google_storage_notification" "govuk_database_backups-govuk_knowledge_graph_staging" {
+  bucket         = google_storage_bucket.govuk_database_backups.name
   payload_format = "JSON_API_V1"
   topic          = "/projects/govuk-knowledge-graph-staging/topics/govuk-integration-database-backups"
   event_types    = ["OBJECT_FINALIZE"]
-  depends_on     = [google_pubsub_topic_iam_policy.govuk_integration_database_backups]
+  depends_on     = [google_pubsub_topic_iam_policy.govuk_database_backups]
 }
 
 # =======================================================
@@ -82,19 +106,23 @@ resource "google_storage_notification" "govuk_integration_database_backups-govuk
 # =======================================================
 
 # Notify the topic from the bucket
-resource "google_storage_notification" "govuk_integration_database_backups-govuk_knowledge_graph_dev" {
-  bucket         = google_storage_bucket.govuk-integration-database-backups.name
+moved {
+  from = google_storage_notification.govuk_integration_database_backups-govuk_knowledge_graph_dev
+  to   = google_storage_notification.govuk_database_backups-govuk_knowledge_graph_dev
+}
+resource "google_storage_notification" "govuk_database_backups-govuk_knowledge_graph_dev" {
+  bucket         = google_storage_bucket.govuk_database_backups.name
   payload_format = "JSON_API_V1"
   topic          = "/projects/govuk-knowledge-graph-dev/topics/govuk-integration-database-backups"
   event_types    = ["OBJECT_FINALIZE"]
-  depends_on     = [google_pubsub_topic_iam_policy.govuk_integration_database_backups]
+  depends_on     = [google_pubsub_topic_iam_policy.govuk_database_backups]
 }
 
 # =========================================================
 # Notify a PubSub topic in the govuk-analytics-test project
 # =========================================================
 resource "google_storage_notification" "support_api_backup_staging" {
-  bucket             = google_storage_bucket.govuk-integration-database-backups.name
+  bucket             = google_storage_bucket.govuk_database_backups.name
   payload_format     = "JSON_API_V1"
   topic              = "projects/govuk-analytics-test/topics/support-api-backup-staging"
   event_types        = ["OBJECT_FINALIZE"]
@@ -105,7 +133,7 @@ resource "google_storage_notification" "support_api_backup_staging" {
 # Notify a PubSub topic in the govuk-user-feedback project
 # =========================================================
 resource "google_storage_notification" "govuk_user_feedback" {
-  bucket             = google_storage_bucket.govuk-integration-database-backups.name
+  bucket             = google_storage_bucket.govuk_database_backups.name
   payload_format     = "JSON_API_V1"
   topic              = "projects/govuk-user-feedback/topics/support-api-backup-staging"
   event_types        = ["OBJECT_FINALIZE"]
@@ -116,7 +144,7 @@ resource "google_storage_notification" "govuk_user_feedback" {
 # Notify a PubSub topic in the govuk-user-feedback-dev project
 # =========================================================
 resource "google_storage_notification" "govuk_user_feedback_dev" {
-  bucket             = google_storage_bucket.govuk-integration-database-backups.name
+  bucket             = google_storage_bucket.govuk_database_backups.name
   payload_format     = "JSON_API_V1"
   topic              = "projects/govuk-user-feedback-dev/topics/support-api-backup-staging"
   event_types        = ["OBJECT_FINALIZE"]

--- a/terraform/transfer.tf
+++ b/terraform/transfer.tf
@@ -8,7 +8,7 @@ moved {
   to   = google_storage_bucket.govuk_database_backups
 }
 resource "google_storage_bucket" "govuk_database_backups" {
-  name                        = "${var.project_id}_govuk-integration-database-backups" # Must be globally unique
+  name                        = "${var.project_id}_govuk-database-backups" # Must be globally unique
   force_destroy               = false                                                  # terraform won't delete the bucket unless it is empty
   storage_class               = "STANDARD"                                             # https://cloud.google.com/storage/docs/storage-classes
   uniform_bucket_level_access = true
@@ -88,7 +88,7 @@ moved {
   to   = google_storage_transfer_job.govuk_database_backups
 }
 resource "google_storage_transfer_job" "govuk_database_backups" {
-  description = "Mirror the GOV.UK S3 bucket govuk-integration-database-backups"
+  description = "Mirror the GOV.UK S3 bucket govuk-staging-database-backups"
 
   transfer_spec {
     object_conditions {

--- a/terraform/transfer.tf
+++ b/terraform/transfer.tf
@@ -94,8 +94,8 @@ resource "google_storage_transfer_job" "govuk-integration-database-backups" {
       delete_objects_from_source_after_transfer  = false
     }
     aws_s3_data_source {
-      bucket_name = "govuk-integration-database-backups"
-      role_arn    = "arn:aws:iam::210287912431:role/google-s3-mirror"
+      bucket_name = "govuk-staging-database-backups"
+      role_arn    = "arn:aws:iam::696911096973:policy/google-s3-mirror"
     }
     gcs_data_sink {
       bucket_name = google_storage_bucket.govuk-integration-database-backups.name

--- a/terraform/transfer.tf
+++ b/terraform/transfer.tf
@@ -3,7 +3,11 @@
 data "google_storage_transfer_project_service_account" "default" {
 }
 
-resource "google_storage_bucket" "govuk-integration-database-backups" {
+moved {
+  from = google_storage_bucket.govuk-integration-database-backups
+  to   = google_storage_bucket.govuk_database_backups
+}
+resource "google_storage_bucket" "govuk_database_backups" {
   name                        = "${var.project_id}_govuk-integration-database-backups" # Must be globally unique
   force_destroy               = false                                                  # terraform won't delete the bucket unless it is empty
   storage_class               = "STANDARD"                                             # https://cloud.google.com/storage/docs/storage-classes
@@ -15,7 +19,7 @@ resource "google_storage_bucket" "govuk-integration-database-backups" {
 }
 
 # Allow the transfer job to use the bucket via its service account
-data "google_iam_policy" "bucket_govuk-integration-database-backups" {
+data "google_iam_policy" "bucket_govuk_database_backups" {
   binding {
     role = "roles/storage.admin"
     members = [
@@ -70,12 +74,20 @@ data "google_iam_policy" "bucket_govuk-integration-database-backups" {
 
 }
 
-resource "google_storage_bucket_iam_policy" "govuk-integration-database-backups" {
-  bucket      = google_storage_bucket.govuk-integration-database-backups.name
-  policy_data = data.google_iam_policy.bucket_govuk-integration-database-backups.policy_data
+moved {
+  from = google_storage_bucket_iam_policy.govuk-integration-database-backups
+  to   = google_storage_bucket_iam_policy.govuk_database_backups
+}
+resource "google_storage_bucket_iam_policy" "govuk_database_backups" {
+  bucket      = google_storage_bucket.govuk_database_backups.name
+  policy_data = data.google_iam_policy.bucket_govuk_database_backups.policy_data
 }
 
-resource "google_storage_transfer_job" "govuk-integration-database-backups" {
+moved {
+  from = google_storage_transfer_job.govuk-integration-database-backups
+  to   = google_storage_transfer_job.govuk_database_backups
+}
+resource "google_storage_transfer_job" "govuk_database_backups" {
   description = "Mirror the GOV.UK S3 bucket govuk-integration-database-backups"
 
   transfer_spec {
@@ -98,7 +110,7 @@ resource "google_storage_transfer_job" "govuk-integration-database-backups" {
       role_arn    = "arn:aws:iam::696911096973:policy/google-s3-mirror"
     }
     gcs_data_sink {
-      bucket_name = google_storage_bucket.govuk-integration-database-backups.name
+      bucket_name = google_storage_bucket.govuk_database_backups.name
     }
   }
 


### PR DESCRIPTION
See the individual commits for more details.

The `Remove "integration" from GCP resource names` commit is potentially the most destructive. We shouldn't apply that unless we're happy to lose the data that's currently in the bucket.