### PR TITLE
Change dev notifications from Int to Staging

### DIFF
--- a/terraform/pubsub-integration.tf
+++ b/terraform/pubsub-integration.tf
@@ -68,19 +68,6 @@ resource "google_storage_notification" "govuk_integration_database_backups-govuk
   depends_on     = [google_pubsub_topic_iam_policy.govuk_integration_database_backups]
 }
 
-# =======================================================
-# A PubSub topic in the govuk-knowledge-graph-dev project
-# =======================================================
-
-# Notify the topic from the bucket
-resource "google_storage_notification" "govuk_integration_database_backups-govuk_knowledge_graph_dev" {
-  bucket         = google_storage_bucket.govuk-integration-database-backups.name
-  payload_format = "JSON_API_V1"
-  topic          = "/projects/govuk-knowledge-graph-dev/topics/govuk-integration-database-backups"
-  event_types    = ["OBJECT_FINALIZE"]
-  depends_on     = [google_pubsub_topic_iam_policy.govuk_integration_database_backups]
-}
-
 # =========================================================
 # Notify a PubSub topic in the govuk-analytics-test project
 # =========================================================

--- a/terraform/pubsub.tf
+++ b/terraform/pubsub.tf
@@ -50,5 +50,16 @@ resource "google_pubsub_subscription" "govuk_database_backups" {
 
   enable_message_ordering = false
 }
-# TODO: Move google_storage_notification notifications from
-#       integration over here, once we're happy things are working
+
+# =======================================================
+# A PubSub topic in the govuk-knowledge-graph-dev project
+# =======================================================
+
+# Notify the topic from the bucket
+resource "google_storage_notification" "govuk_database_backups-govuk_knowledge_graph_dev" {
+  bucket         = google_storage_bucket.govuk_database_backups.name
+  payload_format = "JSON_API_V1"
+  topic          = "/projects/govuk-knowledge-graph-dev/topics/govuk-database-backups"
+  event_types    = ["OBJECT_FINALIZE"]
+  depends_on     = [google_pubsub_topic_iam_policy.govuk_database_backups]
+}


### PR DESCRIPTION
In https://github.com/alphagov/govuk-knowledge-graph-gcp/pull/717 we changed the name of the pubsub topic from
govuk-integration-database-backups to govuk-database-backups.

This changes the storage notification to send messages to the new topic, which should cause the dev version of govuk-knowledge-graph to read from the staging bucket instead of the integration one.