### PR TITLE
Change notifications from Int to Staging in all envs

### DIFF
--- a/terraform/pubsub-integration.tf
+++ b/terraform/pubsub-integration.tf
@@ -42,32 +42,6 @@ resource "google_pubsub_subscription" "govuk_integration_database_backups" {
   enable_message_ordering = false
 }
 
-# ===================================================
-# A PubSub topic in the govuk-knowledge-graph project
-# ===================================================
-
-# Notify the topic from the bucket
-resource "google_storage_notification" "govuk_integration_database_backups-govuk_knowledge_graph" {
-  bucket         = google_storage_bucket.govuk-integration-database-backups.name
-  payload_format = "JSON_API_V1"
-  topic          = "/projects/govuk-knowledge-graph/topics/govuk-integration-database-backups"
-  event_types    = ["OBJECT_FINALIZE"]
-  depends_on     = [google_pubsub_topic_iam_policy.govuk_integration_database_backups]
-}
-
-# =======================================================
-# A PubSub topic in the govuk-knowledge-graph-staging project
-# =======================================================
-
-# Notify the topic from the bucket
-resource "google_storage_notification" "govuk_integration_database_backups-govuk_knowledge_graph_staging" {
-  bucket         = google_storage_bucket.govuk-integration-database-backups.name
-  payload_format = "JSON_API_V1"
-  topic          = "/projects/govuk-knowledge-graph-staging/topics/govuk-integration-database-backups"
-  event_types    = ["OBJECT_FINALIZE"]
-  depends_on     = [google_pubsub_topic_iam_policy.govuk_integration_database_backups]
-}
-
 # =========================================================
 # Notify a PubSub topic in the govuk-analytics-test project
 # =========================================================

--- a/terraform/pubsub.tf
+++ b/terraform/pubsub.tf
@@ -91,7 +91,7 @@ resource "google_storage_notification" "govuk_database_backups-govuk_knowledge_g
 # A PubSub topic in the govuk-knowledge-graph-dev project
 # =======================================================
 
-data "google_pubsub_topic" "govuk_database_backups_knowlege_graph_dev" {
+data "google_pubsub_topic" "govuk_database_backups_knowledge_graph_dev" {
   name    = "govuk-database-backups"
   project = "govuk-knowledge-graph-dev"
 }
@@ -100,7 +100,7 @@ data "google_pubsub_topic" "govuk_database_backups_knowlege_graph_dev" {
 resource "google_storage_notification" "govuk_database_backups-govuk_knowledge_graph_dev" {
   bucket         = google_storage_bucket.govuk_database_backups.name
   payload_format = "JSON_API_V1"
-  topic          = data.google_pubsub_topic.govuk_database_backups_knowlege_graph_dev.id
+  topic          = data.google_pubsub_topic.govuk_database_backups_knowledge_graph_dev.id
   event_types    = ["OBJECT_FINALIZE"]
   depends_on     = [google_pubsub_topic_iam_policy.govuk_database_backups]
 }

--- a/terraform/pubsub.tf
+++ b/terraform/pubsub.tf
@@ -55,11 +55,16 @@ resource "google_pubsub_subscription" "govuk_database_backups" {
 # A PubSub topic in the govuk-knowledge-graph project
 # ===================================================
 
+data "google_pubsub_topic" "govuk_database_backups_knowledge_graph" {
+  name    = "govuk-database-backups"
+  project = "govuk-knowledge-graph"
+}
+
 # Notify the topic from the bucket
 resource "google_storage_notification" "govuk_database_backups-govuk_knowledge_graph" {
   bucket         = google_storage_bucket.govuk_database_backups.name
   payload_format = "JSON_API_V1"
-  topic          = "/projects/govuk-knowledge-graph/topics/govuk-database-backups"
+  topic          = data.google_pubsub_topic.govuk_database_backups_knowledge_graph.id
   event_types    = ["OBJECT_FINALIZE"]
   depends_on     = [google_pubsub_topic_iam_policy.govuk_database_backups]
 }
@@ -68,11 +73,16 @@ resource "google_storage_notification" "govuk_database_backups-govuk_knowledge_g
 # A PubSub topic in the govuk-knowledge-graph-staging project
 # =======================================================
 
+data "google_pubsub_topic" "govuk_database_backups_knowledge_graph_staging" {
+  name    = "govuk-database-backups"
+  project = "govuk-knowledge-graph-staging"
+}
+
 # Notify the topic from the bucket
 resource "google_storage_notification" "govuk_database_backups-govuk_knowledge_graph_staging" {
   bucket         = google_storage_bucket.govuk_database_backups.name
   payload_format = "JSON_API_V1"
-  topic          = "/projects/govuk-knowledge-graph-staging/topics/govuk-database-backups"
+  topic          = data.google_pubsub_topic.govuk_database_backups_knowledge_graph_staging.id
   event_types    = ["OBJECT_FINALIZE"]
   depends_on     = [google_pubsub_topic_iam_policy.govuk_database_backups]
 }

--- a/terraform/pubsub.tf
+++ b/terraform/pubsub.tf
@@ -51,6 +51,32 @@ resource "google_pubsub_subscription" "govuk_database_backups" {
   enable_message_ordering = false
 }
 
+# ===================================================
+# A PubSub topic in the govuk-knowledge-graph project
+# ===================================================
+
+# Notify the topic from the bucket
+resource "google_storage_notification" "govuk_database_backups-govuk_knowledge_graph" {
+  bucket         = google_storage_bucket.govuk_database_backups.name
+  payload_format = "JSON_API_V1"
+  topic          = "/projects/govuk-knowledge-graph/topics/govuk-database-backups"
+  event_types    = ["OBJECT_FINALIZE"]
+  depends_on     = [google_pubsub_topic_iam_policy.govuk_database_backups]
+}
+
+# =======================================================
+# A PubSub topic in the govuk-knowledge-graph-staging project
+# =======================================================
+
+# Notify the topic from the bucket
+resource "google_storage_notification" "govuk_database_backups-govuk_knowledge_graph_staging" {
+  bucket         = google_storage_bucket.govuk_database_backups.name
+  payload_format = "JSON_API_V1"
+  topic          = "/projects/govuk-knowledge-graph-staging/topics/govuk-database-backups"
+  event_types    = ["OBJECT_FINALIZE"]
+  depends_on     = [google_pubsub_topic_iam_policy.govuk_database_backups]
+}
+
 # =======================================================
 # A PubSub topic in the govuk-knowledge-graph-dev project
 # =======================================================


### PR DESCRIPTION
In https://github.com/alphagov/govuk-knowledge-graph-gcp/pull/720 we are changing the name of the pubsub topic from
govuk-integration-database-backups to govuk-database-backups.

This changes the storage notification to send messages to the new topic, which should cause the govuk-knowledge-graph to read from the staging bucket instead of the integration one.

We already did the dev environment in
https://github.com/alphagov/govuk-s3-mirror/pull/67, this covers the other two environments.