### PR TITLE
Fix pubsub topic

### DIFF
--- a/terraform/pubsub.tf
+++ b/terraform/pubsub.tf
@@ -59,7 +59,7 @@ resource "google_pubsub_subscription" "govuk_database_backups" {
 resource "google_storage_notification" "govuk_database_backups-govuk_knowledge_graph_dev" {
   bucket         = google_storage_bucket.govuk_database_backups.name
   payload_format = "JSON_API_V1"
-  topic          = "/projects/govuk-knowledge-graph-dev/topics/govuk-database-backups"
+  topic          = "//pubsub.googleapis.com/projects/govuk-knowledge-graph-dev/topics/govuk-database-backups"
   event_types    = ["OBJECT_FINALIZE"]
   depends_on     = [google_pubsub_topic_iam_policy.govuk_database_backups]
 }

--- a/terraform/pubsub.tf
+++ b/terraform/pubsub.tf
@@ -55,11 +55,16 @@ resource "google_pubsub_subscription" "govuk_database_backups" {
 # A PubSub topic in the govuk-knowledge-graph-dev project
 # =======================================================
 
+data "google_pubsub_topic" "govuk_database_backups" {
+  name    = "govuk-database-backups"
+  project = "govuk-knowledge-graph-dev"
+}
+
 # Notify the topic from the bucket
 resource "google_storage_notification" "govuk_database_backups-govuk_knowledge_graph_dev" {
   bucket         = google_storage_bucket.govuk_database_backups.name
   payload_format = "JSON_API_V1"
-  topic          = "//pubsub.googleapis.com/projects/govuk-knowledge-graph-dev/topics/govuk-database-backups"
+  topic          = google_pubsub_topic.govuk_database_backups.id
   event_types    = ["OBJECT_FINALIZE"]
   depends_on     = [google_pubsub_topic_iam_policy.govuk_database_backups]
 }


### PR DESCRIPTION
Terraform apply was giving the following error:

    │ Error: Error creating notification config for bucket govuk-s3-mirror_govuk-database-backups: googleapi: Error 400: Invalid Google Cloud Pub/Sub topic. It should look like '//pubsub.googleapis.com/projects/*/topics/*.', invalid
    │
    │   with google_storage_notification.govuk_database_backups-govuk_knowledge_graph_dev,
    │   on pubsub.tf line 59, in resource "google_storage_notification" "govuk_database_backups-govuk_knowledge_graph_dev":
    │   59: resource "google_storage_notification" "govuk_database_backups-govuk_knowledge_graph_dev" {

The "It should look like '//pubsub.googleapis.com/...'" suggests that the API has got fussy about the format of these. I'm guessing the ones that already exist aren't a problem because the API used to be more permissive, but because I'm creating this one new I'm hitting the stricter API.

I've already cheekily applied this with the new format, and it appears to be fine. I need to move the other pubsubs over from integration anyway, so I can fix those as and when.