### PR TITLE
Fix reference to topic for storage notifications

### DIFF
--- a/terraform/pubsub.tf
+++ b/terraform/pubsub.tf
@@ -55,7 +55,7 @@ resource "google_pubsub_subscription" "govuk_database_backups" {
 # A PubSub topic in the govuk-knowledge-graph-dev project
 # =======================================================
 
-data "google_pubsub_topic" "govuk_database_backups" {
+data "google_pubsub_topic" "govuk_database_backups_knowlege_graph_dev" {
   name    = "govuk-database-backups"
   project = "govuk-knowledge-graph-dev"
 }
@@ -64,7 +64,7 @@ data "google_pubsub_topic" "govuk_database_backups" {
 resource "google_storage_notification" "govuk_database_backups-govuk_knowledge_graph_dev" {
   bucket         = google_storage_bucket.govuk_database_backups.name
   payload_format = "JSON_API_V1"
-  topic          = google_pubsub_topic.govuk_database_backups.id
+  topic          = data.google_pubsub_topic.govuk_database_backups_knowlege_graph_dev.id
   event_types    = ["OBJECT_FINALIZE"]
   depends_on     = [google_pubsub_topic_iam_policy.govuk_database_backups]
 }


### PR DESCRIPTION
I was accidentally referring to a previously declared resource, rather than the data object I wanted to refer to. It was also named badly, which contributed to the confusion.