### PR TITLE
Include whitehall in backup mirror

### DIFF
--- a/terraform/transfer-integration.tf
+++ b/terraform/transfer-integration.tf
@@ -87,6 +87,7 @@ resource "google_storage_transfer_job" "govuk-integration-database-backups" {
         "publishing-api-postgres/",
         "shared-documentdb/",
         "support-api-postgres/",
+        "whitehall-mysql/",
       ]
     }
     transfer_options {

--- a/terraform/transfer.tf
+++ b/terraform/transfer.tf
@@ -89,6 +89,7 @@ resource "google_storage_transfer_job" "govuk_database_backups" {
         "publishing-api-postgres/",
         "shared-documentdb/",
         "support-api-postgres/",
+        "whitehall-mysql/",
       ]
     }
     transfer_options {


### PR DESCRIPTION
This is needed to push whitehall into Google Big Query.