### PR TITLE
Add Asset Manager  data pipeline service user to objectViewer role for database backup

### DIFF
--- a/terraform/transfer.tf
+++ b/terraform/transfer.tf
@@ -39,6 +39,9 @@ data "google_iam_policy" "bucket_govuk_database_backups" {
       "serviceAccount:gce-whitehall@govuk-knowledge-graph-dev.iam.gserviceaccount.com",
       "serviceAccount:gce-whitehall@govuk-knowledge-graph-staging.iam.gserviceaccount.com",
       "serviceAccount:gce-whitehall@govuk-knowledge-graph.iam.gserviceaccount.com",
+      "serviceAccount:gce-asset-manager@govuk-knowledge-graph-dev.iam.gserviceaccount.com",
+      "serviceAccount:gce-asset-manager@govuk-knowledge-graph-staging.iam.gserviceaccount.com",
+      "serviceAccount:gce-asset-manager@govuk-knowledge-graph.iam.gserviceaccount.com",
       "serviceAccount:data-engineering@govuk-user-feedback-dev.iam.gserviceaccount.com",
       "serviceAccount:data-engineering@govuk-user-feedback.iam.gserviceaccount.com",
     ]


### PR DESCRIPTION
[Trello](https://trello.com/c/MCQYx02N/3598-replicate-the-asset-manager-database-in-google-cloudsql)