### PR TITLE
IA-3009: configure transfer to copy parquet/ files from staging

### DIFF
--- a/terraform/transfer.tf
+++ b/terraform/transfer.tf
@@ -97,6 +97,7 @@ resource "google_storage_transfer_job" "govuk_database_backups" {
         "shared-documentdb/",
         "support-api-postgres/",
         "whitehall-mysql/",
+        "parquet/",
       ]
     }
     transfer_options {


### PR DESCRIPTION
This PR configures the transfer to also copy files from the `parquet/` prefix. 