### PR TITLE
Decommission existing Postgres and MySQL database mirroring feeds, re…

### DIFF
--- a/terraform/transfer-integration.tf
+++ b/terraform/transfer-integration.tf
@@ -84,11 +84,7 @@ resource "google_storage_transfer_job" "govuk-integration-database-backups" {
       include_prefixes = [
         "content-store-postgres/",
         "mongo-api/",
-        "publisher-postgres/",
-        "publishing-api-postgres/",
         "shared-documentdb/",
-        "support-api-postgres/",
-        "whitehall-mysql/",
         "parquet/"
       ]
     }
@@ -114,7 +110,7 @@ resource "google_storage_transfer_job" "govuk-integration-database-backups" {
     }
     start_time_of_day {
       hours   = 00
-      minutes = 00
+      minutes = 30
       seconds = 00
       nanos   = 0
     }

--- a/terraform/transfer.tf
+++ b/terraform/transfer.tf
@@ -98,11 +98,7 @@ resource "google_storage_transfer_job" "govuk_database_backups" {
       include_prefixes = [
         "content-store-postgres/",
         "mongo-api/",
-        "publisher-postgres/",
-        "publishing-api-postgres/",
         "shared-documentdb/",
-        "support-api-postgres/",
-        "whitehall-mysql/",
         "parquet/",
       ]
     }
@@ -128,7 +124,7 @@ resource "google_storage_transfer_job" "govuk_database_backups" {
     }
     start_time_of_day {
       hours   = 00
-      minutes = 00
+      minutes = 30
       seconds = 00
       nanos   = 0
     }


### PR DESCRIPTION

- Decommission the existing Postgres and MySQL database mirroring feeds.
- Retain only their Parquet equivalents to align with the new ingestion pipelines.
- Update the schedule to run hourly at the 30-minute mark to suit ArgoCD timings.